### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.0](https://github.com/fdiakh/slurm-spank-rs/compare/v0.3.0...v0.4.0) - 2025-04-23
+
+### Added
+
+- [**breaking**] pass a mutable reference to self to setup()
+- [**breaking**] pass a SpankHandle to report_error()
+
+### Fixed
+
+- *(examples)* fix renice example
+- properly handle NULL zero-length arrays from Slurm
+
+### Other
+
+- Keep MSRV at 1.72 for now
+- setup github actions
+- upgrade dependencies
+- update edition to 2021

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["example", "test"]
 
 [package]
 name = "slurm-spank"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Francois Diakhate <fdiakh@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `slurm-spank`: 0.3.0 -> 0.4.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/fdiakh/slurm-spank-rs/compare/v0.3.0...v0.4.0) - 2025-04-23

### Added

- [**breaking**] pass a mutable reference to self to setup()
- [**breaking**] pass a SpankHandle to report_error()

### Fixed

- *(examples)* fix renice example
- properly handle NULL zero-length arrays from Slurm

### Other

- Keep MSRV at 1.72 for now
- setup github actions
- upgrade dependencies
- update edition to 2021
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).