### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/fdiakh/slurm-spank-rs/compare/v0.4.0...v0.4.1) - 2025-11-15
+
+### Other
+
+- add release-plz workflow
+- rename main branch
+- update integration tests to Slurm 25.11
+- fix warning from newer rustc
+
 ## [0.4.0](https://github.com/fdiakh/slurm-spank-rs/compare/v0.3.0...v0.4.0) - 2025-04-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["example", "test"]
 
 [package]
 name = "slurm-spank"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Francois Diakhate <fdiakh@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION


## 🤖 New release

* `slurm-spank`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/fdiakh/slurm-spank-rs/compare/v0.4.0...v0.4.1) - 2025-11-15

### Other

- add release-plz workflow with trusted publishing
- update integration tests to Slurm 25.11
- fix warning from newer rustc
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).